### PR TITLE
#151 [Support] Add generic sub-numbering of chapters support via an array of strings

### DIFF
--- a/tests/func/utils/__init__.py
+++ b/tests/func/utils/__init__.py
@@ -39,6 +39,30 @@ def retry(retries=5, abort=True):
     return decorator
 
 
+def retry_on_ex(retry_types, retries=5, abort=True):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            count = 0
+            while count < retries:
+                try:
+                    if count != 0:
+                        time.sleep(1)
+
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    if type(e) in retry_types:
+                        count += 1
+                        print(str(e), file=sys.stderr)
+                    else:
+                        raise
+
+            # Assert if abort is set, when all retries are exhausted
+            assert abort == False
+
+        return wrapper
+    return decorator
+
+
 def check_predicate(errorType, msg):
     def decorator(func):
         def wrapper(self, *args, **kwargs):

--- a/tests/func/utils/support/manganato.py
+++ b/tests/func/utils/support/manganato.py
@@ -1,11 +1,11 @@
 import random
 
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, StaleElementReferenceException, WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
 
 from . import SupportBase
-from .. import RetriableError, retry, check_predicate
+from .. import RetriableError, retry, retry_on_ex, check_predicate
 
 class MangaNatoDriver(SupportBase):
     name = "manganato"
@@ -52,6 +52,7 @@ class MangaNatoDriver(SupportBase):
             by=By.CSS_SELECTOR,
             value='.navi-change-chapter-btn>.navi-change-chapter-btn-prev'))
 
+    @retry_on_ex([StaleElementReferenceException, WebDriverException])
     def prev_page(self):
         # In case you wonder, yes, button with "next" class is actually to go to the previous
         # chapter, because why not!
@@ -65,6 +66,7 @@ class MangaNatoDriver(SupportBase):
             by=By.CSS_SELECTOR,
             value='.navi-change-chapter-btn>.navi-change-chapter-btn-next'))
 
+    @retry_on_ex([StaleElementReferenceException, WebDriverException])
     def next_page(self):
         # In case you wonder, yes, button with "back" class is actually to go to the next
         # chapter, because why not!

--- a/web-extension/support/isekaiscan.js
+++ b/web-extension/support/isekaiscan.js
@@ -48,12 +48,8 @@ IsekaiScanComPlugin.prototype.getInfos = function(url, doc) {
         }
         let name = elem.innerText;
         let homeUrl = elem.getAttribute('href');
-        // XXX BUG XXX:
         // Found some chapters numbered `chapter-0-2` (2nd version of chapter 0 ?)
-        // As such, and to provide an uniform reading experience throughout the
-        // supported readers, we'll only keep the first number...
-        // -> We acknowledge this may lead to a non-functional link later on
-        let chapter = parseInt(url.split('/')[3].split('-')[1]);
+        let chapter = url.split('/')[3].split('-');
         let id = homeUrl.split('/manga/')[1].split('/')[0];
         source = new BmcComicSource(name, 'isekaiscan.com', {id, homeUrl, prefixes: {chapter: chapter_prefix}});
         comic.addSource(source);
@@ -65,7 +61,12 @@ IsekaiScanComPlugin.prototype.getInfos = function(url, doc) {
 
 IsekaiScanComPlugin.prototype.computeURL = function(comic, source) {
     if (comic.chapter !== null) {
-        return `https://isekaiscan.com/manga/${source.info.id}/${source.info.prefixes.chapter}-${comic.chapter}`;
+        // Backwards-compat to before chapter was an array of sub-numberings
+        let chapter_ref = comic.chapter;
+        if (Array.isArray(comic.chapter)) {
+            chapter_ref = comic.chapter.join('-');
+        }
+        return `https://isekaiscan.com/manga/${source.info.id}/${source.info.prefixes.chapter}-${chapter_ref}`;
     }
     return comic.homeUrl;
 };

--- a/web-extension/support/mangafox.js
+++ b/web-extension/support/mangafox.js
@@ -36,7 +36,7 @@ FanFoxNetPlugin.prototype.getInfos = function(url, doc) {
         const homeUrl = elem.getAttribute('href');
         const link_parts = url.split('/manga/')[1].split('/');
         const id = link_parts[0];
-        const chapter = parseInt(link_parts[1].replace('c', ''), 10);
+        const chapter = link_parts[1].replace('c', '').split('.');
         let page = link_parts[2].replace('.html', '');
         // BEWARE ! On FanFox, browsing uses ajax, and may update browsing url
         // with a '#' anchor to show which page is currently viewed. The HTML
@@ -61,7 +61,13 @@ FanFoxNetPlugin.prototype.computeURL = function(comic, source) {
     // Might be configurable later on.
     let url = `https://fanfox.net/manga/${source.info.id}`;
     if (comic.chapter) {
-        url += `/c${comic.chapter.toString().padStart(3, '0')}/${comic.page}.html`;
+        // Backwards-compat to before chapter was an array of sub-numberings
+        let chapter_ref = comic.chapter.toString().padStart(3, '0');
+        if (Array.isArray(comic.chapter)) {
+            const subs = comic.chapter.splice(1);
+            chapter_ref = [comic.chapter[0].padStart(3, '0'), subs.join('.')].join('.');
+        }
+        url += `/c${chapter_ref}/${comic.page}.html`;
         if (comic.page !== '1') {
             url = `${url}#ipg${comic.page}`;
         }

--- a/web-extension/support/mangakakalot.js
+++ b/web-extension/support/mangakakalot.js
@@ -16,7 +16,7 @@ MangaKakalotComPlugin.prototype.getInfos = function(url, doc) {
     if (parts.length < 1) {
         return null;
     } else if (parts[parts.length - 1].indexOf('chapter_') !== 0) {
-        // manga page
+        // manga homepage
         let elem = doc.querySelector('.manga-info-top>.manga-info-text>li>h1');
         if (!elem) {
             LOGS.log('S77');
@@ -41,8 +41,8 @@ MangaKakalotComPlugin.prototype.getInfos = function(url, doc) {
         }
         let name = elems[1].children[0].innerText;
         let homeUrl = elems[1].getAttribute('href').split('mangakakalot.com')[1];
-        let chapter = parts[parts.length - 1].split('_');
-        chapter = parseInt(chapter[chapter.length - 1]);
+        const ctoks = parts[parts.length - 1].split('_');
+        const chapter = ctoks[ctoks.length - 1].split('.');
         let id = parts[parts.length - 2];
         source = new BmcComicSource(name, 'mangakakalot.com', {id, homeUrl});
         comic.addSource(source);
@@ -57,7 +57,12 @@ MangaKakalotComPlugin.prototype.computeURL = function(comic, source) {
     // working out of the box, so we might as well enforce HTTPS as a default.
     // Might be configurable later on.
     if (comic.chapter) {
-        return `https://mangakakalot.com/chapter/${source.info.id}/chapter_${comic.chapter}`;
+        // Backwards-compat to before chapter was an array of sub-numberings
+        let chapter_ref = comic.chapter;
+        if (Array.isArray(comic.chapter)) {
+            chapter_ref = comic.chapter.join('.');
+        }
+        return `https://mangakakalot.com/chapter/${source.info.id}/chapter_${chapter_ref}`;
     }
     return `https://mangakakalot.com/${source.info.homeUrl}`;
 };

--- a/web-extension/support/manganato.js
+++ b/web-extension/support/manganato.js
@@ -35,7 +35,7 @@ MangaNatoComPlugin.prototype.getInfos = function(url, doc) {
         }
         const name = elems[1].innerText;
         const homeUrl = elems[1].getAttribute('href').split('manganato.com')[1];
-        const chapter = parseInt(parts[parts.length - 1].split('-')[1]);
+        const chapter = parts[parts.length - 1].split('-')[1].split('.');
         const id = parts[parts.length - 2].split('-')[1];
         source = new BmcComicSource(name, 'readmanganato.com', {id: id, homeUrl: homeUrl});
         comic.chapter = chapter;
@@ -51,7 +51,11 @@ MangaNatoComPlugin.prototype.computeURL = function(comic, source) {
     // working out of the box, so we might as well enforce HTTPS as a default.
     // Might be configurable later on.
     if (comic.chapter) {
-        return `https://readmanganato.com/manga-${source.info.id}/chapter-${comic.chapter}`;
+        let chapter_ref = comic.chapter;
+        if (Array.isArray(comic.chapter)) {
+            chapter_ref = comic.chapter.join('.');
+        }
+        return `https://readmanganato.com/manga-${source.info.id}/chapter-${chapter_ref}`;
     }
     return `https://readmanganato.com${source.info.homeUrl}`;
 };


### PR DESCRIPTION
Storing an array of number strings will allow:
 - Avoid crashing on unexpected characters
 - Re-joining the numbering parts with the right reader's splitter char (as
   opposed to storing the full chapter reference)

Fixes #151