### PR TITLE
#155 Implement mechanism to check all tracked comics/sources for new chapter/pages

### DIFF
--- a/tests/func/test_sidebar_display.py
+++ b/tests/func/test_sidebar_display.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 EXT = Extension()
 SIDEBAR_WIDTH = 206
-COLLAPSED_SIDEBAR_HEIGHT = 58
+COLLAPSED_SIDEBAR_HEIGHT = 86
 
 
 @pytest.mark.order(after='test_webext_loads')

--- a/web-extension/engine/datamodel.js
+++ b/web-extension/engine/datamodel.js
@@ -194,7 +194,7 @@ KeyScheme.prototype.computeSourceKey = function(source) {
 function BmcComicSource(name, reader, info) {
     this.name = name.trim();
     this.reader = reader;
-    this.info = Object.assign({}, info);
+    this.info = Object.assign({has_updates: false}, info);
 }
 
 /**
@@ -889,5 +889,27 @@ BmcDataAPI.prototype.getComic = function(comicId, cb) {
             return cb(null, null);
         }
         return cb(null, results[0]);
+    });
+};
+
+/**
+ * This method updates a single ComicSource's data.
+ *
+ * @method
+ *
+ * @param {BmcComic} the comic containing the source to update
+ * @param {BmcComicSource} the source to update
+ *
+ * @returns {undefined}
+ */
+BmcDataAPI.prototype.updateComicSource = function(comicId, source, cb) {
+    return this._scheme.getMap((err, map) => {
+        const sourceKey = this._scheme.computeSourceKey(source);
+        map[sourceKey] = { id: comicId, info: source.info };
+        const dataset = {};
+        dataset[this._scheme.BMC_MAP_KEY] = map;
+        return this._data.set(dataset, err => {
+            return cb(err);
+        });
     });
 };

--- a/web-extension/engine/ui.js
+++ b/web-extension/engine/ui.js
@@ -22,7 +22,7 @@ BmcUI.prototype.buildSidePanel = function(setupTracker, resourcePath) {
     iframe.src = resourcePath;
     LOGS.log('S31', {'src': iframe.src});
     iframe.style.width = '206px';
-    iframe.style.height = '58px';
+    iframe.style.height = '86px';
     iframe.style.position = 'fixed';
     iframe.style.top = '70px';
     iframe.style.left = '0';
@@ -85,7 +85,7 @@ BmcUI.prototype.fullSize = function(showSidebar) {
         iframe.style.height = '100vh';
         iframe.style.top = '0';
     } else {
-        iframe.style.height = '58px';
+        iframe.style.height = '86px';
         iframe.style.top = '70px';
     }
 };

--- a/web-extension/scripts/load-bookmarks.js
+++ b/web-extension/scripts/load-bookmarks.js
@@ -612,7 +612,7 @@ function addEvents() {
         BmcUI.prototype.SIDEPANEL_ID,
         ev => ev.data.type === 'action' && ev.data.action === 'notification',
         ev => {
-            LOGS.log('S53', {'op': ev.data.operation, 'error': ev.data.error});
+            LOGS.log('S53', {'op': ev.data.operation, 'error': JSON.stringify(ev.data.error)});
             notifyResult(ev.data.operation, ev.data.error);
         });
     bmcMessaging.addExtensionHandler(

--- a/web-extension/scripts/load-bookmarks.js
+++ b/web-extension/scripts/load-bookmarks.js
@@ -58,6 +58,10 @@ function sendAliasRequest(comicId) {
     });
 }
 
+function getRefreshBut() {
+    return document.getElementById('refresh-but');
+}
+
 BmcMangaList.prototype.onBrowseClick = function(ev) {
     let target = ev.target;
     let comicWrapper = target.parentElement;
@@ -447,7 +451,7 @@ function addEvents() {
     }
 
     // On button-add click, Trigger a new comic registration
-    const refreshBtn = document.getElementById('refresh-but');
+    const refreshBtn = getRefreshBut();
     if (refreshBtn) {
         refreshBtn.onclick = checkForUpdates;
     }
@@ -660,11 +664,13 @@ function addEvents() {
             && ev.data.operation === 'Check Updates',
         ev => {
             if (ev.data.step === 'started') {
-                // TODO STOP rotation animation of refresh-but
-                document.getElementById('refresh-but').style.backgroundColor = '#85dd00';
+                const refreshBut = getRefreshBut();
+                refreshBut.style.backgroundColor = '#85dd00';
+                refreshBut.querySelector('.fa-rotate').classList.add('rotate');
             } else if (ev.data.step === 'completed') {
-                // TODO  STOP rotation animation of refresh-but
-                document.getElementById('refresh-but').style.backgroundColor = '#fcfcfc';
+                const refreshBut = getRefreshBut();
+                refreshBut.style.backgroundColor = '#fcfcfc';
+                refreshBut.querySelector('.fa-rotate').classList.remove('rotate');
             } else if (ev.data.step === 'source') {
                 const evComic = BmcComic.deserialize(ev.data.comic);
                 const evSource = BmcComicSource.fromDict(ev.data.source);
@@ -764,7 +770,7 @@ function shiftButtonLeft(btn) {
 }
 
 function moveButtonsToTheRightPlace(panel) {
-    var refBtn = document.getElementById('refresh-but');
+    var refBtn = getRefreshBut();
     var togBtn = document.getElementById('hide-but');
     var regBtn = document.getElementById('register-but');
     var delBtn = document.getElementById('delete-but');
@@ -884,7 +890,7 @@ function showSidePanelAdder() {
     }
     var sidePanel = document.getElementById('side-panel');
     var hideBut = document.getElementById('hide-but');
-    var refreshBtn = document.getElementById('refresh-but');
+    var refreshBtn = getRefreshBut();
     var regBtn = document.getElementById('register-but');
     var delBtn = document.getElementById('delete-but');
     var bookmarkName = document.getElementById('bookmark-name');

--- a/web-extension/sidebar.html
+++ b/web-extension/sidebar.html
@@ -24,8 +24,18 @@
   top: calc(50% - 7px);
   display: none;
 }
+.label-container > .fa-rotate {
+  position: absolute;
+  right: 2px;
+  top: calc(50% - 7px);
+  display: block;
+}
 .fa-trash::before {
   content: "\f1f8";
+}
+.fa-rotate::before {
+  content: "\f2f1";
+  content: "\f1ce";
 }
 .label-container {
   position: relative;
@@ -36,8 +46,14 @@
 .label:hover + .fa-trash, .fa-trash:hover {
   display: initial;
 }
+.label:hover + .fa-rotate, .fa-rotate:hover {
+  display: initial;
+}
 .label-container > .fa-trash:hover {
   color: red;
+}
+.label-container > .fa-rotate:hover {
+  color: #fcfcfc;
 }
 #side-panel,#side-panel-adder,#side-panel-add-into-existing {
   width: calc(100vw - 22px);
@@ -49,6 +65,36 @@
   background-color: #fcfcfc;
   left: 0;
   display: none;
+}
+#refresh-but {
+  position: absolute;
+  top: 58px;
+  padding: 3px;
+  padding-top: 2px;
+  background-color: #fcfcfc;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 14px;
+  cursor: pointer;
+  width: 18px;
+  text-align: center;
+  transition: left .3s, right .3s;
+}
+#refresh-but.left {
+  left: -6px;
+}
+#refresh-but.left:hover {
+  left: 0;
+}
+#refresh-but.right {
+  top: 128px;
+  right: 0;
+}
+#refresh-but.right:hover {
+  right: 4px;
+}
+#refresh-but:hover {
+  background-color: #ebebeb;
 }
 #hide-but {
   position: absolute;
@@ -260,6 +306,9 @@ ul, .mangaListItem {
 .current {
   background: #f9e3d0;
 }
+.readable {
+  background: #a3f9a0;
+}
     </style>
     <script src="strings.js"></script>
     <script src="utils.js"></script>
@@ -290,6 +339,7 @@ ul, .mangaListItem {
       <button id="add-existing-confirm" class="button-add" disabled>Confirm</button>
       <button id="add-existing-cancel" class="button-add cancel">Cancel</button>
     </div>
+    <div id="refresh-but" class="left"><span class="fa fa-rotate"></span></div>
     <div id="register-but" class="left">+</div>
     <div id="delete-but" class="left"><span class="fa fa-trash"></span></div>
     <div id="hide-but" class="left">&gt;</div>

--- a/web-extension/sidebar.html
+++ b/web-extension/sidebar.html
@@ -34,8 +34,7 @@
   content: "\f1f8";
 }
 .fa-rotate::before {
-  content: "\f2f1";
-  content: "\f1ce";
+  content: "\f021";
 }
 .label-container {
   position: relative;
@@ -65,6 +64,17 @@
   background-color: #fcfcfc;
   left: 0;
   display: none;
+}
+@keyframes rotating {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+.rotate {
+  animation: rotating 2s linear infinite;
 }
 #refresh-but {
   position: absolute;

--- a/web-extension/sources.js
+++ b/web-extension/sources.js
@@ -77,6 +77,11 @@ BmcSources.prototype.computeURL = function(origin, comic) {
     return ori ? ori.computeURL(comic, comic.getSource(origin)) : null;
 };
 
+BmcSources.prototype.hasNextPage = function(origin, doc) {
+    var ori = this._fromOrigin(origin);
+    return ori ? ori.hasNextPage(doc) : false;
+};
+
 BmcSources.prototype.getInfos = function(origin, url, doc) {
     var ori = this._fromOrigin(origin);
     return ori ? ori.getInfos(url, doc) : null;

--- a/web-extension/strings.js
+++ b/web-extension/strings.js
@@ -38,7 +38,7 @@ function Localization(lang = DEFAULT_LANG) {
             'en': 'BmcEngine._memoizeComic: unknown comic name.',
         },
         // 'S3': {
-        //     'en': 'BmcEngine: Resetting ID memoization after end of ongoing memoization',
+        //     'en': 'BmcEngine: Check Update failed for  comic {label}: Could not match source {reader}',
         // },
         // 'S4': {
         //     'en': 'BmcEngine: Resetting ID memoization',
@@ -300,7 +300,7 @@ function Logs(level = INFO) {
         // 'E0005': 'S6',
         // 'E0006': 'S7',
         'E0007': 'S8',
-        // 'E0008': 'S27',
+        // 'E0008': 'S3',
         'E0009': 'S17',
         'E0010': 'S15',
         'E0011': 'S13',

--- a/web-extension/support/isekaiscan.js
+++ b/web-extension/support/isekaiscan.js
@@ -70,3 +70,8 @@ IsekaiScanComPlugin.prototype.computeURL = function(comic, source) {
     }
     return comic.homeUrl;
 };
+
+IsekaiScanComPlugin.prototype.hasNextPage = function(doc) {
+    const elem = doc.querySelector('.nav-next > .next_page');
+    return elem !== null;
+};

--- a/web-extension/support/mangafox.js
+++ b/web-extension/support/mangafox.js
@@ -76,3 +76,32 @@ FanFoxNetPlugin.prototype.computeURL = function(comic, source) {
     }
     return url;
 };
+
+FanFoxNetPlugin.prototype.hasNextPage = function(doc) {
+    let pages = null;
+    let chapters = null;
+    const pagers = doc.getElementsByClassName('pager-list-left');
+    for (let i=0; i < pagers.length; i++) {
+        if (pagers[i].childElementCount) {
+            pages = pagers[i].querySelectorAll('span > a');
+            chapters = pagers[i].querySelectorAll('a.chapter');
+            break ;
+        }
+    }
+
+    // Check if we're on the last page of the chapter
+    for (let i=0; i < pages.length; i++) {
+        if (pages[i].classList.contains('active')) {
+            if (i < pages.length - 1) {
+                return true;
+            }
+            // If yes, check if there's a next chapter
+            for (let i=0; i < chapters.length; i++) {
+                if (chapters[i].text.indexOf('Next') !== -1) {
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+};

--- a/web-extension/support/mangafox.js
+++ b/web-extension/support/mangafox.js
@@ -2,6 +2,7 @@
     BmcComicSource:readable
     BmcComic:readable
     LOGS:readable
+    cloneArray:readable
 */
 
 function FanFoxNetPlugin() {
@@ -64,11 +65,12 @@ FanFoxNetPlugin.prototype.computeURL = function(comic, source) {
         // Backwards-compat to before chapter was an array of sub-numberings
         let chapter_ref = comic.chapter.toString().padStart(3, '0');
         if (Array.isArray(comic.chapter)) {
-            const subs = comic.chapter.splice(1);
-            chapter_ref = [comic.chapter[0].padStart(3, '0'), subs.join('.')].join('.');
+            const subs = cloneArray(comic.chapter).splice(1);
+            const ar = [comic.chapter[0].padStart(3, '0')].concat(subs.length ? [subs.join('.')] : []);
+            chapter_ref = ar.join('.');
         }
-        url += `/c${chapter_ref}/${comic.page}.html`;
-        if (comic.page !== '1') {
+        url += `/c${chapter_ref}/${comic.page ? comic.page : 1}.html`;
+        if (comic.page !== null && comic.page !== '1') {
             url = `${url}#ipg${comic.page}`;
         }
     }

--- a/web-extension/support/mangakakalot.js
+++ b/web-extension/support/mangakakalot.js
@@ -66,3 +66,8 @@ MangaKakalotComPlugin.prototype.computeURL = function(comic, source) {
     }
     return `https://mangakakalot.com/${source.info.homeUrl}`;
 };
+
+MangaKakalotComPlugin.prototype.hasNextPage = function(doc) {
+    const elem = doc.querySelector('.btn-navigation-chap > .back');
+    return elem !== null;
+};

--- a/web-extension/support/manganato.js
+++ b/web-extension/support/manganato.js
@@ -59,3 +59,8 @@ MangaNatoComPlugin.prototype.computeURL = function(comic, source) {
     }
     return `https://readmanganato.com${source.info.homeUrl}`;
 };
+
+MangaNatoComPlugin.prototype.hasNextPage = function(doc) {
+    const elem = doc.querySelector('.navi-change-chapter-btn>.navi-change-chapter-btn-next');
+    return elem !== null;
+};

--- a/web-extension/utils.js
+++ b/web-extension/utils.js
@@ -9,3 +9,40 @@ function cloneArray(arr) {
     // iteration.
     return Array.prototype.slice.call(arr);
 }
+
+
+/*
+ * Credit for these function goes to
+ * https://gomakethings.com/converting-a-string-into-markup-with-vanilla-js/
+ *
+ * Thanks for providing us with a reliable method to load HTML from text data.
+ *
+ */
+//
+const supports_DOMParser = (function () {
+    if (!window.DOMParser)
+        return false;
+    var parser = new DOMParser();
+    try {
+        parser.parseFromString('x', 'text/html');
+    } catch(err) {
+        return false;
+    }
+    return true;
+})();
+
+/* eslint-disable-next-line no-unused-vars */
+function stringToHTML(str) {
+
+    // If DOMParser is supported, use it
+    if (supports_DOMParser) {
+        var parser = new DOMParser();
+        var doc = parser.parseFromString(str, 'text/html');
+        return doc.body;
+    }
+
+    // Otherwise, fallback to old-school method
+    var dom = document.createElement('div');
+    dom.innerHTML = str;
+    return dom;
+}


### PR DESCRIPTION
See commit messages for detail

Note: Currently, this MR is lacking:
 - UI/UX refinement
 - Dedicated Tests for the support modules + multi-sources update check (only the relevant sources should have the `readable` class)
 - Automated new chapter availability check upon registering a Comic/Source

There is also a point to discuss:
 - Whether all comics/sources should be checked, or should we skip checking the sources known to have newer chapters available.
 - Upon receiving a tracking notification in the SidePanel, only the current comic/source couple is checked for newer chapters/pages, and not the other sources for the current comic. Maybe we should  add this ?

closes #155